### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,4 +1,6 @@
 name: Build and Test
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/DevelApp-ai/MarkdownStructureChunker/security/code-scanning/1](https://github.com/DevelApp-ai/MarkdownStructureChunker/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow to explicitly set the minimum required permissions for the `GITHUB_TOKEN`. Since the workflow only needs to check out code and does not interact with the repository in a way that requires write access, the minimal permission required is `contents: read`. This can be set at the workflow level (applies to all jobs) or at the job level. The best practice is to set it at the workflow level, immediately after the `name` field and before `on`, so that all jobs inherit this restriction unless overridden.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
