### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,8 @@ jobs:
   create-release:
     name: Create Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     
     steps:
     - name: Checkout code


### PR DESCRIPTION
Potential fix for [https://github.com/DevelApp-ai/MarkdownStructureChunker/security/code-scanning/2](https://github.com/DevelApp-ai/MarkdownStructureChunker/security/code-scanning/2)

To fix the problem, add an explicit `permissions` block to the workflow. This can be done at the workflow level (applies to all jobs) or at the job level (applies only to the specific job). Since there is only one job (`create-release`), either location is acceptable, but adding it at the job level is more precise and aligns with the CodeQL suggestion. The minimal required permissions for this workflow are:

- `contents: write` (required for pushing commits and creating releases)
- Optionally, if the workflow interacts with issues or pull requests, those permissions can be added, but based on the shown steps, only `contents: write` is needed.

Add the following block under the `create-release` job definition (after `runs-on`):

```yaml
permissions:
  contents: write
```

No additional imports or dependencies are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
