### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -48,6 +48,8 @@ jobs:
         
   build-package:
     name: Build NuGet Package
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     needs: test
     


### PR DESCRIPTION
Potential fix for [https://github.com/DevelApp-ai/MarkdownStructureChunker/security/code-scanning/4](https://github.com/DevelApp-ai/MarkdownStructureChunker/security/code-scanning/4)

To fix the problem, add an explicit `permissions` block to the `build-package` job in `.github/workflows/ci-cd.yml`. This block should specify the minimum required permissions for the job. Since the job only checks out code, builds, and uploads artifacts (and does not push code or interact with issues, PRs, or releases), the minimal permission required is `contents: read`. This change should be made directly under the `build-package:` job definition, before the `runs-on` key.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
