### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -87,6 +87,8 @@ jobs:
 
   publish-nuget:
     name: Publish to NuGet
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     needs: [test, build-package]
     if: github.event_name == 'release' && github.event.action == 'published'


### PR DESCRIPTION
Potential fix for [https://github.com/DevelApp-ai/MarkdownStructureChunker/security/code-scanning/5](https://github.com/DevelApp-ai/MarkdownStructureChunker/security/code-scanning/5)

To fix the problem, add an explicit `permissions` block to the `publish-nuget` job in `.github/workflows/ci-cd.yml`. The minimal required permission is `contents: read`, which allows the job to read repository contents if needed, but does not grant write access or other unnecessary privileges. This change should be made directly under the `publish-nuget` job definition, before the `runs-on` key (to match the structure of the other jobs). No additional imports or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
