### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -129,6 +129,9 @@ jobs:
 
   publish-github-packages:
     name: Publish to GitHub Packages
+    permissions:
+      contents: read
+      packages: write
     runs-on: ubuntu-latest
     needs: [test, build-package]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'


### PR DESCRIPTION
Potential fix for [https://github.com/DevelApp-ai/MarkdownStructureChunker/security/code-scanning/6](https://github.com/DevelApp-ai/MarkdownStructureChunker/security/code-scanning/6)

To fix the problem, add a `permissions` block to the `publish-github-packages` job, restricting the permissions of the `GITHUB_TOKEN` to the minimum required. Since the job only needs to publish packages to GitHub Packages (which requires `packages: write`) and possibly read repository contents, the minimal starting point is `contents: read`. However, for publishing to GitHub Packages, the job also needs `packages: write`. Therefore, set:

```yaml
permissions:
  contents: read
  packages: write
```

This should be added as the first key under the `publish-github-packages` job (i.e., after `name:` and before `runs-on:`).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
